### PR TITLE
no console pop-up in pyinstaller exe

### DIFF
--- a/raw2aif_gui.spec
+++ b/raw2aif_gui.spec
@@ -30,4 +30,4 @@ exe = EXE(pyz,
           upx=True,
           upx_exclude=[],
           runtime_tmpdir=None,
-          console=True )
+          console=False )


### PR DESCRIPTION
the executable currently displays a console when invoked, this should disable it and make it more "app-like"