### PR TITLE
Feature / isobar

### DIFF
--- a/examples/various/isobar.aif
+++ b/examples/various/isobar.aif
@@ -2,7 +2,7 @@
 
 data_isobar_co2
 
-    _audit_aif_version                "v1.0.0"
+    _audit_aif_version                "__AIF_VERSION__"
 
     _exptl_operator                   "Hannah Lee"
     _exptl_date                       2024-07-12T09:00:00Z

--- a/examples/various/isobar.aif
+++ b/examples/various/isobar.aif
@@ -1,0 +1,38 @@
+# Isobar measurement - CO2 amount vs temperature at constant pressure
+
+data_isobar_co2
+
+    _audit_aif_version                "v1.0.0"
+
+    _exptl_operator                   "Hannah Lee"
+    _exptl_date                       2024-07-12T09:00:00Z
+    _exptl_adsorptive                 "Carbon Dioxide"
+    _exptl_adsorptive_name            "CO2"
+    _exptl_method                     "gravimetric"
+    _exptl_instrument                 "DVS Vacuum"
+    _exptl_isotherm_type              "absolute"
+    _exptl_pressure                   100000.0
+
+    _adsnt_material_id                "Zeolite-5A"
+    _adsnt_sample_id                  "Z5A-isobar-01"
+    _adsnt_sample_mass                0.0567
+
+    _units_temperature                "K"
+    _units_pressure                   "Pa"
+    _units_mass                       "g"
+    _units_loading                    "mmol/g"
+
+    loop_
+        _isobar_temperature
+        _isobar_amount
+        _isobar_pressure
+        298.15   4.52   100000.0
+        313.15   3.89   100000.0
+        333.15   3.12   100000.0
+        353.15   2.45   100000.0
+        373.15   1.89   100000.0
+        393.15   1.34   100000.0
+        413.15   0.89   100000.0
+        433.15   0.56   100000.0
+        453.15   0.34   100000.0
+        473.15   0.18   100000.0

--- a/proposal.md
+++ b/proposal.md
@@ -1,0 +1,55 @@
+# AIF Dictionary Improvement Proposal
+
+## 1 — Motivation
+
+The current AIF dictionary (`aif_dictionary.json`, `.dic`, `.yaml`) defines 51
+data names covering isothermal adsorption and desorption measurements. However,
+files already present in this repository use data names that fall outside the
+dictionary. This proposal catalogues those names and recommends how to
+incorporate them.
+
+---
+
+## 2 — Proposal A: Isobar Data Category
+
+### Background
+
+An isobar measures the adsorbed amount as a function of **temperature** at a
+**constant pressure** — the complement of an isotherm (amount vs pressure at
+constant temperature). This is a standard experiment in adsorption science, and
+the AIF format should be able to represent it natively.
+
+The example file `examples/various/isobar.aif` already demonstrates the
+pattern: a `loop_` block with columns `_isobar_temperature`,
+`_isobar_amount`, and `_isobar_pressure`.
+
+### Proposed data names
+
+A new **ISOBAR** category (Section 9 in the JSON Schema) with three loop
+columns:
+
+| Data name | Type | Description |
+|---|---|---|
+| `_exptl_pressure` | number | Pressure held constant during the isobar measurement, analogue of `_exptl_temperature` for an isotherm (see `_units_temperature`) |
+| `_isobar_temperature` | number | Temperature at each isobar data point (see `_units_temperature`) |
+| `_isobar_amount` | number | Amount adsorbed at each isobar data point (see `_units_loading`) |
+| `_isobar_pressure` | number | Pressure held constant during the isobar measurement, recorded per row to allow multi-pressure datasets in a single loop (see `_units_pressure`) |
+
+### Design questions
+
+1. **What is the cycle up/down naming?**.
+
+2. **Possible extensions.**
+   - `_isobar_amount_excess`, `_isobar_amount_absolute`, `_isobar_amount_net`
+     — mirroring the isotherm's three loading conventions.
+   - `_isobar_fugacity` — for high-pressure isobars where fugacity corrections
+     are needed.
+   These can be added in a follow-up proposal if there is demand.
+
+---
+
+## 5 — Version impact
+
+Adding a new data category is a **backward-compatible** change (new optional
+fields only), so it warrants a **minor** version bump under SemVer.
+


### PR DESCRIPTION
# AIF Dictionary Improvement Proposal

Note: AI asissted document

## 1 — Motivation

The current AIF dictionary can be extended to cover isobar measurements (single pressure, changing temperature).

---

## 2 — Proposal A: Isobar Data Category

### Background

An isobar measures the adsorbed amount as a function of **temperature** at a **constant pressure** — the complement of an isotherm (amount vs pressure at constant temperature). This is a standard experiment in adsorption science, and the AIF format should be able to represent it natively.

The example file [isobar.aif](`examples/various/isobar.aif`) demonstrates the pattern: a `loop_` block with columns `_isobar_temperature`, `_isobar_amount`, and `_isobar_pressure`.

### Proposed data names

A new **ISOBAR** category (Section 9 in the JSON Schema) with three loop columns:

| Data name | Type | Description |
|---|---|---|
| `_exptl_pressure` | number | Pressure held constant during the isobar measurement, analogue of `_exptl_temperature` for an isotherm (see `_units_temperature`) |
| `_isobar_temperature` | number | Temperature at each isobar data point (see `_units_temperature`) |
| `_isobar_amount` | number | Amount adsorbed at each isobar data point (see `_units_loading`) |
| `_isobar_pressure` | number | Pressure held constant during the isobar measurement, recorded per row to allow multi-pressure datasets in a single loop (see `_units_pressure`) |

### Design questions

1. **What is the cycle up/down naming?**.

2. **Possible extensions.**
   - `_isobar_amount_excess`, `_isobar_amount_absolute`, `_isobar_amount_net`
     — mirroring the isotherm's three loading conventions.
   - `_isobar_fugacity` — for high-pressure isobars where fugacity corrections
     are needed.
   These can be added in a follow-up proposal if there is demand.

---

## 5 — Version impact

Adding a new data category is a **backward-compatible** change (new optional
fields only).

